### PR TITLE
Add support for caching multiple workflows

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,5 +1,7 @@
 name: CI
-on: push
+on:
+  push:
+  pull_request:
 concurrency:
   # Skip intermediate builds: always.
   # Cancel intermediate builds: only if it is a pull request build.

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /Manifest.toml
+
+test/MultipleWorkflows/**/Manifest.toml
+.vscode/*

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ path = build(path_to_project; platform = Base.BinaryPlatforms.HostPlatform())
 - Run this in the production environment to get started: `include("$path/config/depot_startup.jl")`.
 
 ### Example 2
+This example shows how to build a depo path from different Project.toml files, enabling precompilation as needed.
 ```julia
 using DepotDelivery: build
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,12 @@
 
 - Bundles all necessary Julia code and artifacts needed to run without internet access.
 - Build for platforms other than the host platform.
+- Can build multiple packages/projects into a single path.
+- Can precompile all dependencies to built path.
 
 ## Usage
 
+### Example 1
 ```julia
 using DepotDelivery: build
 
@@ -24,6 +27,17 @@ path = build(path_to_project; platform = Base.BinaryPlatforms.HostPlatform())
 - Your project lives at `$path/dev/MyProject`.
 - The build settings live in `$path/config/depot_build.toml`
 - Run this in the production environment to get started: `include("$path/config/depot_startup.jl")`.
+
+### Example 2
+```julia
+using DepotDelivery: build
+
+# We can provide a depot_path to share DEPOT_PATH 
+depot_path = "path/to/depot/"
+
+# Assumes `path/Project.toml` exists (or `path/JuliaProject.toml`) in each entry of first argument, and force precompilation.
+path = build(["path/project-1", "path-2/project-2"]; depot=depot_path, precompiled=true)
+```
 
 ## Building for Non-Host Platforms
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ depot_path = "path/to/depot/"
 path = build(["path/project-1", "path-2/project-2"]; depot=depot_path, precompiled=true)
 ```
 
+Be aware that `build` will copy everything inside those directories to `depot_path/dev/`. Avoid populating those directories with unnecessary files. For example, when starting a new project, it's better to run `julia --project=./isolated_folder/` rather than `julia --project=.`, as in the latter case the `Project.toml` file will coexist with other stuff.
+
 ## Building for Non-Host Platforms
 
 - Use any `Base.BinaryPlatforms.AbstractPlatform` as the `platform` argument.

--- a/src/DepotDelivery.jl
+++ b/src/DepotDelivery.jl
@@ -74,6 +74,13 @@ function build(path::String; platform = Base.BinaryPlatforms.HostPlatform(), ver
     return depot
 end
 
+function build(paths::Vector{String}; platform = Base.BinaryPlatforms.HostPlatform(), verbose=true, depot=mktempdir(), precompiled=false)
+    for path in paths
+        build(path; platform=platform, verbose=verbose, depot=depot, precompiled=precompiled)
+    end
+ end
+ 
+
 #-----------------------------------------------------------------------------# startup_script
 startup_script(name) = """
     import Pkg

--- a/src/DepotDelivery.jl
+++ b/src/DepotDelivery.jl
@@ -69,10 +69,7 @@ function build(path::String; platform = Base.BinaryPlatforms.HostPlatform(), ver
         # Disabling precompile for non-host platforms
         precompiled ? delete!(ENV, "JULIA_PKG_PRECOMPILE_AUTO") : ENV["JULIA_PKG_PRECOMPILE_AUTO"] = "0" 
 
-        for file in filter(f -> endswith(f, ".toml"), readdir(path))
-            # Copy only .toml files into dev/
-            cp(joinpath(path, file), joinpath(depot, "dev", name, file), force=true) 
-        end
+        cp(path, joinpath(depot, "dev", name))  # Copy project into dev/
  
         Pkg.activate(joinpath(depot, "dev", name))
         Pkg.instantiate(; platform, verbose)

--- a/src/DepotDelivery.jl
+++ b/src/DepotDelivery.jl
@@ -69,7 +69,7 @@ function build(path::String; platform = Base.BinaryPlatforms.HostPlatform(), ver
         # Disabling precompile for non-host platforms
         precompiled ? delete!(ENV, "JULIA_PKG_PRECOMPILE_AUTO") : ENV["JULIA_PKG_PRECOMPILE_AUTO"] = "0" 
 
-        cp(path, joinpath(depot, "dev", name))  # Copy project into dev/
+        cp(path, joinpath(depot, "dev", name), force=true)  # Copy project into dev/
  
         Pkg.activate(joinpath(depot, "dev", name))
         Pkg.instantiate(; platform, verbose)
@@ -85,7 +85,7 @@ function build(path::String; platform = Base.BinaryPlatforms.HostPlatform(), ver
         open(io -> TOML.print(io, build_spec), joinpath(depot, "config", "depot_build.toml"), "w")
         open(io -> print(io, startup_script(name)), joinpath(depot, "config", "depot_startup.jl"), "w")
     end
-
+    
     return depot
 end
 
@@ -108,6 +108,7 @@ function build(paths::Vector{String}; platform = Base.BinaryPlatforms.HostPlatfo
     for path in paths
         build(path; platform=platform, verbose=verbose, depot=depot, precompiled=precompiled)
     end
+    return depot
  end
  
 

--- a/src/DepotDelivery.jl
+++ b/src/DepotDelivery.jl
@@ -36,7 +36,7 @@ function build(path::String; platform = Base.BinaryPlatforms.HostPlatform(), ver
         proj_file = isfile(proj_file) ? proj_file : joinpath(path, "JuliaProject.toml")
         isfile(proj_file) || error("No Project.toml or JuliaProject.toml found in `$path`.")
         proj = TOML.parsefile(proj_file)
-        name = proj["name"]
+        name = haskey(proj, "name") ? proj["name"] : Base.basename(Base.dirname(proj_file))
         build_spec = Dict(
             :datetime => Dates.now(),
             :versioninfo => sprint(InteractiveUtils.versioninfo),

--- a/src/DepotDelivery.jl
+++ b/src/DepotDelivery.jl
@@ -28,9 +28,9 @@ function sandbox(f::Function)
 end
 
 #-----------------------------------------------------------------------------# build
-function build(path::String; platform = Base.BinaryPlatforms.HostPlatform(), verbose=true)
+function build(path::String; platform = Base.BinaryPlatforms.HostPlatform(), verbose=true, depot = mktempdir())
     path = abspath(path)
-    depot = mktempdir()
+    mkpath(depot)
     sandbox() do
         proj_file = joinpath(path, "Project.toml")
         proj_file = isfile(proj_file) ? proj_file : joinpath(path, "JuliaProject.toml")
@@ -44,8 +44,8 @@ function build(path::String; platform = Base.BinaryPlatforms.HostPlatform(), ver
             :project => proj,
             :platform => string(platform)
         )
-        mkdir(joinpath(depot, "config"))
-        mkdir(joinpath(depot, "dev"))
+        mkpath(joinpath(depot, "config"))
+        mkpath(joinpath(depot, "dev", name))
         push!(empty!(DEPOT_PATH), depot)
         ENV["JULIA_PKG_PRECOMPILE_AUTO"] = "0"  # Needed when building for non-host platforms
 

--- a/src/DepotDelivery.jl
+++ b/src/DepotDelivery.jl
@@ -28,7 +28,7 @@ function sandbox(f::Function)
 end
 
 #-----------------------------------------------------------------------------# build
-function build(path::String; platform = Base.BinaryPlatforms.HostPlatform(), verbose=true, depot = mktempdir())
+function build(path::String; platform = Base.BinaryPlatforms.HostPlatform(), verbose=true, depot = mktempdir(), precompiled=false)
     path = abspath(path)
     mkpath(depot)
     sandbox() do
@@ -47,7 +47,9 @@ function build(path::String; platform = Base.BinaryPlatforms.HostPlatform(), ver
         mkpath(joinpath(depot, "config"))
         mkpath(joinpath(depot, "dev", name))
         push!(empty!(DEPOT_PATH), depot)
-        ENV["JULIA_PKG_PRECOMPILE_AUTO"] = "0"  # Needed when building for non-host platforms
+        
+        # Disabling precompile for non-host platforms
+        precompiled ? delete!(ENV, "JULIA_PKG_PRECOMPILE_AUTO") : ENV["JULIA_PKG_PRECOMPILE_AUTO"] = "0" 
 
         cp(path, joinpath(depot, "dev", name))  # Copy project into dev/
         Pkg.activate(joinpath(depot, "dev", name))

--- a/src/DepotDelivery.jl
+++ b/src/DepotDelivery.jl
@@ -51,7 +51,11 @@ function build(path::String; platform = Base.BinaryPlatforms.HostPlatform(), ver
         # Disabling precompile for non-host platforms
         precompiled ? delete!(ENV, "JULIA_PKG_PRECOMPILE_AUTO") : ENV["JULIA_PKG_PRECOMPILE_AUTO"] = "0" 
 
-        cp(path, joinpath(depot, "dev", name))  # Copy project into dev/
+        for file in filter(f -> endswith(f, ".toml"), readdir(path))
+            # Copy .toml files into dev/
+            cp(joinpath(path, file), joinpath(depot, "dev", name, file), force=true) 
+        end
+ 
         Pkg.activate(joinpath(depot, "dev", name))
         Pkg.instantiate(; platform, verbose)
 

--- a/test/MultipleWorkflows/BitFlags/Project.toml
+++ b/test/MultipleWorkflows/BitFlags/Project.toml
@@ -1,0 +1,2 @@
+[deps]
+BitFlags = "d1d4a3ce-64b1-5f1a-9ba4-7e7e69966f35"

--- a/test/MultipleWorkflows/URIs/Project.toml
+++ b/test/MultipleWorkflows/URIs/Project.toml
@@ -1,0 +1,2 @@
+[deps]
+URIs = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"

--- a/test/MultipleWorkflows/Unzip/Project.toml
+++ b/test/MultipleWorkflows/Unzip/Project.toml
@@ -1,0 +1,2 @@
+[deps]
+Unzip = "41fe7b60-77ed-43a1-b4f0-825fd5a5650d"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using DepotDelivery
 using Pkg
 using Test
 
+
 depot = DepotDelivery.build(joinpath(@__DIR__, "TestProject"))
 
 @test DepotDelivery.test(depot)
@@ -32,6 +33,7 @@ DepotDelivery.sandbox() do
     # and the depot path does not point to the default value
     @testset for (proj, package) in zip(proj_paths, packages_list)
         Pkg.activate(proj)
+        Pkg.status()
         package_symbol = Symbol(package)
         @eval using $package_symbol
         package_value = eval(package_symbol)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,9 +20,7 @@ depot2 = DepotDelivery.build(joinpath(@__DIR__, "TestProject"), platform = Pkg.B
 path = joinpath(depot2, "packages", "HDF5_jll")
 
 
-#------------------------------------------------------------------------------------
-#------------------------------------------------------------------------------------
-# Testing multiple workflows
+#-----------------------------------------------------------------------------# Testing multiple workflows
 packages_list = readdir("MultipleWorkflows/");
 proj_paths = joinpath.("./MultipleWorkflows/", packages_list);
 depot = DepotDelivery.build(proj_paths, precompiled=true)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,8 +21,8 @@ path = joinpath(depot2, "packages", "HDF5_jll")
 
 
 #-----------------------------------------------------------------------------# Testing multiple workflows
-packages_list = readdir("MultipleWorkflows/");
-proj_paths = joinpath.("./MultipleWorkflows/", packages_list);
+packages_list = readdir(joinpath(@__DIR__, "MultipleWorkflows/"));
+proj_paths = joinpath.(@__DIR__, "MultipleWorkflows/", packages_list);
 depot = DepotDelivery.build(proj_paths, precompiled=true)
 
 DepotDelivery.sandbox() do 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,6 +42,6 @@ DepotDelivery.sandbox() do
 
     # Ensure compiled folders are populated
     @testset for package in packages_list
-        @test length(readdir(joinpath(depot, "compiled", "v$(VERSION.major).$(VERSION.minor)", package))) > 1
+        @test length(readdir(joinpath(depot, "compiled", "v$(VERSION.major).$(VERSION.minor)", package))) > 0
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,7 +33,7 @@ DepotDelivery.sandbox() do
     # and the depot path does not point to the default value
     @testset for (proj, package) in zip(proj_paths, packages_list)
         Pkg.activate(proj)
-        Pkg.status()
+        Pkg.instantiate()
         package_symbol = Symbol(package)
         @eval using $package_symbol
         package_value = eval(package_symbol)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,3 +18,30 @@ end
 depot2 = DepotDelivery.build(joinpath(@__DIR__, "TestProject"), platform = Pkg.BinaryPlatforms.Windows(:x86_64))
 
 path = joinpath(depot2, "packages", "HDF5_jll")
+
+
+#------------------------------------------------------------------------------------
+#------------------------------------------------------------------------------------
+# Testing multiple workflows
+packages_list = readdir("MultipleWorkflows/");
+proj_paths = joinpath.("./MultipleWorkflows/", packages_list);
+depot = DepotDelivery.build(proj_paths, precompiled=true)
+
+DepotDelivery.sandbox() do 
+    push!(empty!(DEPOT_PATH), depot)
+    
+    # Test that for every project instantiated, their dependencies exist 
+    # and the depot path does not point to the default value
+    @testset for (proj, package) in zip(proj_paths, packages_list)
+        Pkg.activate(proj)
+        package_symbol = Symbol(package)
+        @eval using $package_symbol
+        package_value = eval(package_symbol)
+        @test !occursin(".julia", pathof(package_value))
+    end
+
+    # Ensure compiled folders are populated
+    @testset for package in packages_list
+        @test length(readdir(joinpath(depot, "compiled", "v$(VERSION.major).$(VERSION.minor)", package))) > 1
+    end
+end


### PR DESCRIPTION
This pull request addresses a need that we have at CERN (high energy physics) where we need to prepare Julia artifacts to support multiple workflows. The artifacts are prepared and then installed on [CernVM-FS](https://cernvm.cern.ch/fs/) - a high performance distributed read-only file system used by the LHC experiments (and many other scientific communities).

The changes made implement the following features:
- Support for user-defined `DEPOT_PATH` destination.
- Support for `Project.toml` files that are generated by the project dependencies of an application (which may not be a package). This support includes being able to create multiple subdirectories of the target depot path and copying only the relevant (`.toml`) files to the final destination. 
- Support for caching artifacts to support multiple workflows.
- Added usage example in the README.md file.

To make use of this package at CERN, we gather a list of directories that contain `Project.toml` files for a number of relevant workflows. Using DepotDelivery, we build all the dependencies into a single depot path inside CernVM-FS, with the new precompiled flag set to true. After publishing this depot path to CernVM-FS these files are visible to machines connected to the grid. This greatly reduces the startup time of applications running in our distributed computing infrastructure.

See the updated readme file for an example (current usage of the script is completely unaffected)

Thanks for creating such a useful script. With these extensions we can really nicely satisfy our use case.  
